### PR TITLE
Prefix some keywords with TOK_ 

### DIFF
--- a/EscriptLexer.g4
+++ b/EscriptLexer.g4
@@ -12,7 +12,7 @@ ELSE:               'else';
 GOTO:               'goto';
 // GOSUB:              'gosub'; // not used??
 RETURN:             'return';
-CONST:              'const';
+TOK_CONST:          'const';
 VAR:                'var';
 DO:                 'do';
 DOWHILE:            'dowhile';
@@ -47,11 +47,11 @@ ENDENUM:            'endenum';
 DOWNTO:             'downto';
 STEP:               'step';
 REFERENCE:          'reference';
-OUT:                'out';
-INPUT:              'inout';
+TOK_OUT:            'out';
+INOUT:              'inout';
 BYVAL:              'ByVal';
 STRING:             'string';
-LONG:               'long';
+TOK_LONG:           'long';
 INTEGER:            'integer';
 UNSIGNED:           'unsigned';
 SIGNED:             'signed';
@@ -73,13 +73,13 @@ BANG_B:             'not';
 fragment BANG:      '!' | 'not';
 BYREF:              'byref';
 UNUSED:             'unused';
-ERROR:              'error';
+TOK_ERROR:          'error';
 HASH:               'hash';
 DICTIONARY:         'dictionary';
 STRUCT:             'struct';
 ARRAY:              'array';
 STACK:              'stack';
-IN:                 'in';
+TOK_IN:             'in';
 
 // Literals
 

--- a/EscriptParser.g4
+++ b/EscriptParser.g4
@@ -109,7 +109,7 @@ returnStatement
     ;
 
 constStatement
-    : CONST variableDeclaration ';' 
+    : TOK_CONST variableDeclaration ';'
     ;
 
 varStatement
@@ -145,7 +145,7 @@ forStatement
     ;
 
 foreachStatement
-    : FOREACH IDENTIFIER IN expression block ENDFOREACH
+    : FOREACH IDENTIFIER TOK_IN expression block ENDFOREACH
     ;
 
 repeatStatement
@@ -255,7 +255,7 @@ expression
     | ARRAY arrayInitializer?
     | STRUCT structInitializer?
     | DICTIONARY dictInitializer?
-    | ERROR structInitializer?
+    | TOK_ERROR structInitializer?
     | '{' expressionList? '}'
     | '@' IDENTIFIER
     | expression postfix=('++' | '--')


### PR DESCRIPTION
because otherwise they clash with 20-year-old windows header definitions.